### PR TITLE
2024/08/20 - version: 0.6.17+44

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,105 @@
 
 # ChangeLog
 
+## 2024/08/20 - version: 0.6.17+44
+
+Update: Refactor Mechanics IDs and Various Model Updates. Files and Changes:
+
+1. `lib/common/models/ad.dart`
+   - Updated `mechanicsId` from `List<int>` to `List<String>` to reflect changes in ID management.
+
+2. `lib/common/models/boardgame.dart`
+   - Renamed the `id` field to `bgId`.
+   - Updated `mechanics` to `mechsPsIds`, changing the type from `List<int>` to `List<String>`.
+
+3. `lib/common/models/filter.dart`
+   - Changed `mechanicsId` to `mechanicsPsId` and updated its type from `List<int>` to `List<String>`.
+
+4. `lib/common/settings/local_server.dart`
+   - Added `keyParseServerImageUrl` to manage image URLs more efficiently.
+
+5. `lib/common/singletons/app_settings.dart`
+   - Enhanced `_saveBright()` to save brightness settings as 'dark' or 'light' strings.
+
+6. `lib/components/custon_field_controllers/numeric_edit_controller.dart`
+   - Improved the `numericValue` setter to better manage old values and trigger appropriate UI updates.
+
+7. `lib/components/others_widgets/spin_box_field.dart`
+   - Refactored to use generics, allowing support for both `int` and `double` types in `SpinBoxField`.
+
+8. `lib/features/boardgame/boardgame_screen.dart`
+   - Refined the floating action button to allow for multiple actions with tooltips for better UX.
+
+9. `lib/features/edit_ad/edit_ad_controller.dart`
+   - Updated `setMechanicsIds()` to `setMechanicsPsIds()` to handle the new `String` ID format.
+
+10. `lib/features/edit_ad/widgets/ad_form.dart`
+    - Refactored to use the new `setMechanicsPsIds()` method.
+
+11. `lib/features/edit_boardgame/edit_boardgame_controller.dart`
+    - Updated mechanics handling to reflect changes from `int` to `String` for IDs.
+    - Introduced a method for updating existing board games.
+
+12. `lib/features/edit_boardgame/edit_boardgame_screen.dart`
+    - Modified the initialization to pass `BoardgameModel` objects where applicable.
+
+13. `lib/features/filters/filters_controller.dart`
+    - Changed `selectedMechIds` from `List<int>` to `List<String>`.
+    - Updated method calls to align with this change.
+
+14. `lib/features/filters/filters_screen.dart`
+    - Refined the mechanics selection process to handle `String` IDs.
+
+15. `lib/features/mechanics/mechanics_controller.dart`
+    - Adapted the controller to work with `String` IDs.
+    - Updated methods for selecting and managing mechanics.
+
+16. `lib/features/mechanics/mechanics_screen.dart`
+    - Updated arguments and state management to work with `String` IDs instead of `int`.
+
+17. `lib/features/mechanics/widgets/show_all_mechs.dart`
+    - Refined to handle `String` IDs, ensuring compatibility with the rest of the application.
+
+18. `lib/features/my_account/widgets/admin_hooks.dart`
+    - Adjusted to pass `String` IDs in the navigation arguments for mechanics management.
+
+19. `lib/manager/boardgames_manager.dart`
+    - Implemented `update()` method to handle board game updates with the new `String` ID format.
+    - Renamed `saveNewBoardgame()` to `save()` for consistency.
+
+20. `lib/manager/mechanics_manager.dart`
+    - Updated to handle `String` IDs for mechanics.
+    - Modified the `add()` method to return the new mechanic after saving it to the server.
+
+21. `lib/my_material_app.dart`
+    - Adjusted routes to pass `BoardgameModel` objects where required.
+    - Updated mechanics selection to handle `String` IDs.
+
+22. `lib/repository/parse_server/common/constants.dart`
+    - Removed the now redundant `keyMechId` constant.
+
+23. `lib/repository/parse_server/common/parse_to_model.dart`
+    - Updated parsing logic to handle `String` IDs for mechanics and board games.
+
+24. `lib/repository/parse_server/ps_ad_repository.dart`
+    - Refined to work with `String` IDs for mechanics within advertisements.
+
+25. `lib/repository/parse_server/ps_boardgame_repository.dart`
+    - Implemented an `update()` method for board games, ensuring proper handling of the new `String` IDs.
+
+26. `lib/repository/parse_server/ps_mechanics_repository.dart`
+    - Changed method names and return types to work with `String` IDs.
+    - Removed the setting of `mechId` in the `add()` method, now relying on `objectId`.
+
+27. `lib/store/constants/migration_sql_scripts.dart`
+    - Added a placeholder for a future migration script (version 1002).
+
+28. `lib/store/stores/mechanics_store.dart`
+    - Updated queries to include the new `mechPSId` column.
+
+This commit introduces significant changes to the handling of mechanics and board game IDs across the codebase, migrating from `int` to `String` IDs for better compatibility with the Parse server. The update also includes improvements in UI components and overall data management.
+
+
 ## 2024/08/20 - version: 0.6.17+43
 
 

--- a/lib/common/models/ad.dart
+++ b/lib/common/models/ad.dart
@@ -33,7 +33,7 @@ class AdModel {
   bool hidePhone;
   double price;
   AdStatus status;
-  List<int> mechanicsId;
+  List<String> mechanicsId;
   AddressModel? address;
   List<String> images;
   ProductCondition condition;

--- a/lib/common/models/boardgame.dart
+++ b/lib/common/models/boardgame.dart
@@ -16,7 +16,7 @@
 // along with bgbazzar.  If not, see <https://www.gnu.org/licenses/>.
 
 class BoardgameModel {
-  String? id;
+  String? bgId;
   String name;
   String image;
   int publishYear;
@@ -29,10 +29,10 @@ class BoardgameModel {
   String? artist;
   String? description;
   int views;
-  List<int> mechanics;
+  List<String> mechsPsIds;
 
   BoardgameModel({
-    this.id,
+    this.bgId,
     required this.name,
     required this.image,
     required this.publishYear,
@@ -45,7 +45,7 @@ class BoardgameModel {
     this.artist,
     this.description,
     this.views = 0,
-    required this.mechanics,
+    required this.mechsPsIds,
   });
 
   static String cleanDescription(String text) {
@@ -61,7 +61,7 @@ class BoardgameModel {
   @override
   String toString() {
     return 'BoardgameModel('
-        ' id: $id,\n'
+        ' id: $bgId,\n'
         ' name: $name,\n'
         ' image: $image,\n'
         ' yearpublished: $publishYear,\n'
@@ -74,6 +74,6 @@ class BoardgameModel {
         ' artist: $artist,\n'
         ' description: $description,\n'
         ' views: $views,\n'
-        ' boardgamemechanic: $mechanics)';
+        ' boardgamemechanic: $mechsPsIds)';
   }
 }

--- a/lib/common/models/filter.dart
+++ b/lib/common/models/filter.dart
@@ -27,7 +27,7 @@ class FilterModel {
   String city;
   SortOrder sortBy;
   ProductCondition condition;
-  List<int> mechanicsId;
+  List<String> mechanicsPsId;
   int minPrice;
   int maxPrice;
 
@@ -36,17 +36,17 @@ class FilterModel {
     this.city = '',
     this.sortBy = SortOrder.date,
     this.condition = ProductCondition.all,
-    List<int>? mechanicsId,
+    List<String>? mechanicsId,
     this.minPrice = 0,
     this.maxPrice = 0,
-  }) : mechanicsId = mechanicsId ?? [];
+  }) : mechanicsPsId = mechanicsId ?? [];
 
   bool get isEmpty {
     return state.isEmpty &&
         city.isEmpty &&
         sortBy == SortOrder.date &&
         condition == ProductCondition.all &&
-        mechanicsId.isEmpty &&
+        mechanicsPsId.isEmpty &&
         minPrice == 0 &&
         maxPrice == 0;
   }
@@ -59,7 +59,7 @@ class FilterModel {
         other.city == city &&
         other.sortBy == sortBy &&
         other.condition == condition &&
-        listEquals(other.mechanicsId, mechanicsId) &&
+        listEquals(other.mechanicsPsId, mechanicsPsId) &&
         other.minPrice == minPrice &&
         other.maxPrice == maxPrice;
   }
@@ -70,7 +70,7 @@ class FilterModel {
         city.hashCode ^
         sortBy.hashCode ^
         condition.hashCode ^
-        mechanicsId.hashCode ^
+        mechanicsPsId.hashCode ^
         minPrice.hashCode ^
         maxPrice.hashCode;
   }
@@ -80,7 +80,7 @@ class FilterModel {
     city = f.city;
     sortBy = f.sortBy;
     condition = f.condition;
-    mechanicsId = f.mechanicsId;
+    mechanicsPsId = f.mechanicsPsId;
     minPrice = f.minPrice;
     maxPrice = f.maxPrice;
   }

--- a/lib/common/settings/local_server.dart
+++ b/lib/common/settings/local_server.dart
@@ -24,4 +24,6 @@ class LocalServer {
   static get keyApplicationId => 'IYbf1NRGo31PJbm4SUfibVvBS6XX4LyVfXwb6Vbd';
   static get keyClientKey => 'UXD8yIPFSaVQ3Wk46gPErwcVkl5c40pp00hH306q';
   static get keyParseServerUrl => 'https://parseapi.back4app.com';
+
+  static get keyParseServerImageUrl => 'https://parsefiles.back4app.com';
 }

--- a/lib/common/singletons/app_settings.dart
+++ b/lib/common/singletons/app_settings.dart
@@ -48,7 +48,10 @@ class AppSettings {
 
   Future<void> _saveBright() async {
     final prefs = await SharedPreferences.getInstance();
-    prefs.setString(keyBrightness, _brightness.value.toString());
+    prefs.setString(
+      keyBrightness,
+      _brightness.value == Brightness.dark ? 'dark' : 'light',
+    );
   }
 
   Future<void> setLocalDBVersion(int version) async {

--- a/lib/components/custon_field_controllers/numeric_edit_controller.dart
+++ b/lib/components/custon_field_controllers/numeric_edit_controller.dart
@@ -27,7 +27,10 @@ class NumericEditController<T extends num> extends TextEditingController {
     throw UnsupportedError('Unsupported type: $T');
   }
 
-  set numericValue(T value) => text = value.toString();
+  set numericValue(T value) {
+    oldValue = value.toString();
+    _setControllerText();
+  }
 
   bool _isValidateValue = false;
 

--- a/lib/features/boardgame/boardgame_screen.dart
+++ b/lib/features/boardgame/boardgame_screen.dart
@@ -114,23 +114,30 @@ class _BoardgameScreenState extends State<BoardgameScreen> {
       floatingActionButton: ctrl.isAdmin
           ? OverflowBar(
               children: [
-                FloatingActionButton.extended(
+                FloatingActionButton(
                   heroTag: 'Fab01',
                   onPressed: _addBoardgame,
-                  icon: const Icon(Icons.add),
-                  label: const Text('Adicionar'),
+                  tooltip: 'Adicionar',
+                  child: const Icon(Icons.add),
                 ),
                 const SizedBox(width: 20),
-                FloatingActionButton.extended(
+                FloatingActionButton(
                   heroTag: 'Fab02',
                   onPressed: _editBoardgame,
-                  icon: const Icon(Icons.edit),
-                  label: const Text('Editar'),
+                  tooltip: 'Editar',
+                  child: const Icon(Icons.edit),
+                ),
+                const SizedBox(width: 20),
+                FloatingActionButton(
+                  heroTag: 'Fab03',
+                  onPressed: _viewBoardgame,
+                  tooltip: 'Visualizar',
+                  child: const Icon(Icons.visibility),
                 ),
               ],
             )
           : FloatingActionButton.extended(
-              heroTag: 'Fab03',
+              heroTag: 'Fab04',
               onPressed: _viewBoardgame,
               icon: const Icon(Icons.visibility),
               label: const Text('Visualizar'),

--- a/lib/features/edit_ad/edit_ad_controller.dart
+++ b/lib/features/edit_ad/edit_ad_controller.dart
@@ -61,7 +61,7 @@ class EditAdController extends ChangeNotifier {
 
   final _images = <String>[];
   final _imagesLength = ValueNotifier<int>(0);
-  final List<int> _selectedMechIds = [];
+  final List<String> _selectedMechPsIds = [];
 
   String _selectedAddressId = '';
   String get selectedAddressId => _selectedAddressId;
@@ -73,9 +73,9 @@ class EditAdController extends ChangeNotifier {
   ProductCondition get condition => _condition;
   AdStatus get adStatus => _adStatus;
 
-  List<int> get selectedMechIds => _selectedMechIds;
+  List<String> get selectedMechIds => _selectedMechPsIds;
   List<String> get selectedMachNames => mechanics
-      .where((c) => _selectedMechIds.contains(c.id!))
+      .where((c) => _selectedMechPsIds.contains(c.psId!))
       .map((c) => c.name)
       .toList();
 
@@ -93,7 +93,7 @@ class EditAdController extends ChangeNotifier {
       hidePhone.value = editAd.hidePhone;
       priceController.currencyValue = editAd.price;
       setAdStatus(editAd.status);
-      setMechanicsIds(editAd.mechanicsId);
+      setMechanicsPsIds(editAd.mechanicsId);
       setSelectedAddress(editAd.address!.name);
       setImages(editAd.images);
       setCondition(editAd.condition);
@@ -148,7 +148,7 @@ class EditAdController extends ChangeNotifier {
       _changeState(EditAdStateLoading());
       final bg = await bgManager.getBoardgameId(bgId);
       if (bg != null) {
-        setMechanicsIds(bg.mechanics);
+        setMechanicsPsIds(bg.mechsPsIds);
         nameController.text = bg.name;
         ad.title = bg.name;
         ad.yearpublished = bg.publishYear;
@@ -159,7 +159,7 @@ class EditAdController extends ChangeNotifier {
         ad.age = bg.minAge;
         ad.designer = bg.designer;
         ad.artist = bg.artist;
-        ad.mechanicsId = bg.mechanics;
+        ad.mechanicsId = bg.mechsPsIds;
         ad.images.add(bg.image);
       }
       log(ad.toString());
@@ -172,9 +172,9 @@ class EditAdController extends ChangeNotifier {
     }
   }
 
-  void setMechanicsIds(List<int> mechIds) {
-    _selectedMechIds.clear();
-    _selectedMechIds.addAll(mechIds);
+  void setMechanicsPsIds(List<String> mechPsIds) {
+    _selectedMechPsIds.clear();
+    _selectedMechPsIds.addAll(mechPsIds);
     mechanicsController.text = selectedMachNames.join(', ');
   }
 
@@ -195,7 +195,7 @@ class EditAdController extends ChangeNotifier {
       ad.images = _images;
       ad.title = nameController.text;
       ad.description = descriptionController.text;
-      ad.mechanicsId = _selectedMechIds;
+      ad.mechanicsId = _selectedMechPsIds;
       ad.address = currentUser.addresses
           .firstWhere((address) => address.id == _selectedAddressId);
       ad.price = priceController.currencyValue;
@@ -222,7 +222,7 @@ class EditAdController extends ChangeNotifier {
       ad.images = _images;
       ad.title = nameController.text;
       ad.description = descriptionController.text;
-      ad.mechanicsId = _selectedMechIds;
+      ad.mechanicsId = _selectedMechPsIds;
       ad.address = currentUser.addresses
           .firstWhere((address) => address.id == _selectedAddressId);
       ad.price = priceController.currencyValue;

--- a/lib/features/edit_ad/widgets/ad_form.dart
+++ b/lib/features/edit_ad/widgets/ad_form.dart
@@ -48,14 +48,14 @@ class _AdFormState extends State<AdForm> {
   }
 
   Future<void> _addMecanics() async {
-    final mechIds = await Navigator.pushNamed(
+    final mechPsIds = await Navigator.pushNamed(
       context,
       MechanicsScreen.routeName,
       arguments: ctrl.selectedMechIds,
-    ) as List<int>?;
+    ) as List<String>?;
 
-    if (mechIds != null) {
-      ctrl.setMechanicsIds(mechIds);
+    if (mechPsIds != null) {
+      ctrl.setMechanicsPsIds(mechPsIds);
       if (mounted) FocusScope.of(context).nextFocus();
     }
   }

--- a/lib/features/edit_boardgame/edit_boardgame_screen.dart
+++ b/lib/features/edit_boardgame/edit_boardgame_screen.dart
@@ -19,6 +19,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import '../../common/models/boardgame.dart';
 import '../../common/theme/app_text_style.dart';
 import '../../components/form_fields/custom_form_field.dart';
 import '../../components/form_fields/custom_long_form_field.dart';
@@ -32,7 +33,12 @@ import 'edit_boardgame_controller.dart';
 import 'edit_boardgame_state.dart';
 
 class EditBoardgamesScreen extends StatefulWidget {
-  const EditBoardgamesScreen({super.key});
+  final BoardgameModel? bg;
+
+  const EditBoardgamesScreen(
+    this.bg, {
+    super.key,
+  });
 
   static const routeName = '/boardgame';
 
@@ -47,7 +53,7 @@ class _EditBoardgamesScreenState extends State<EditBoardgamesScreen> {
   void initState() {
     super.initState();
 
-    ctrl.init();
+    ctrl.init(widget.bg);
   }
 
   @override
@@ -108,14 +114,14 @@ class _EditBoardgamesScreenState extends State<EditBoardgamesScreen> {
   }
 
   Future<void> _addMecanics() async {
-    final mechIds = await Navigator.pushNamed(
+    final mechPsIds = await Navigator.pushNamed(
       context,
       MechanicsScreen.routeName,
       arguments: ctrl.selectedMechIds,
-    ) as List<int>?;
+    ) as List<String>?;
 
-    if (mechIds != null) {
-      ctrl.setMechanicsIds(mechIds);
+    if (mechPsIds != null) {
+      ctrl.setMechanicsPsIds(mechPsIds);
       if (mounted) FocusScope.of(context).nextFocus();
     }
   }

--- a/lib/features/filters/filters_controller.dart
+++ b/lib/features/filters/filters_controller.dart
@@ -49,8 +49,8 @@ class FiltersController extends ChangeNotifier {
   StateBrModel? get selectedState => _selectedState;
   CityModel? get selectesCity => _selectedCity;
 
-  final List<int> _selectedMechIds = [];
-  List<int> get selectedMechIds => _selectedMechIds;
+  final List<String> _selectedMechIds = [];
+  List<String> get selectedMechIds => _selectedMechIds;
 
   final stateController = TextEditingController();
   final cityController = TextEditingController();
@@ -98,7 +98,7 @@ class FiltersController extends ChangeNotifier {
     _filter.sortBy = filter.sortBy;
     _filter.condition = filter.condition;
     _selectedMechIds.clear();
-    _selectedMechIds.addAll(filter.mechanicsId);
+    _selectedMechIds.addAll(filter.mechanicsPsId);
 
     if (filter.state.isNotEmpty) {
       submitState(filter.state);
@@ -118,10 +118,10 @@ class FiltersController extends ChangeNotifier {
         maxPrice: maxPriceController.currencyValue.toInt(),
       );
 
-  void mechUpdateNames(List<int> mechIds) {
+  void mechUpdateNames(List<String> mechPsIds) {
     _selectedMechIds.clear();
-    _selectedMechIds.addAll(mechIds);
-    final mechNames = mechManager.namesFromIdList(_selectedMechIds);
+    _selectedMechIds.addAll(mechPsIds);
+    final mechNames = mechManager.namesFromPsIdList(_selectedMechIds);
     mechsController.text = _joinMechNames(mechNames);
   }
 

--- a/lib/features/filters/filters_screen.dart
+++ b/lib/features/filters/filters_screen.dart
@@ -67,12 +67,12 @@ class _FiltersScreenState extends State<FiltersScreen> {
   }
 
   Future<void> _selectMechanics() async {
-    final newMechsIds = await Navigator.pushNamed(
+    final newMechsPsIds = await Navigator.pushNamed(
       context,
       MechanicsScreen.routeName,
       arguments: ctrl.selectedMechIds,
-    ) as List<int>;
-    ctrl.mechUpdateNames(newMechsIds);
+    ) as List<String>;
+    ctrl.mechUpdateNames(newMechsPsIds);
   }
 
   @override

--- a/lib/features/mechanics/mechanics_controller.dart
+++ b/lib/features/mechanics/mechanics_controller.dart
@@ -40,22 +40,22 @@ class MechanicsController extends ChangeNotifier {
   final mechanicManager = getIt<MechanicsManager>();
 
   List<MechanicModel> get mechanics => mechanicManager.mechanics;
-  MechanicModel Function(int id) get mechanicOfId =>
-      mechanicManager.mechanicOfId;
+  MechanicModel Function(String psId) get mechanicOfPsId =>
+      mechanicManager.mechanicOfPsId;
 
-  final List<int> _selectedIds = [];
+  final List<String> _selectedPsIds = [];
   final _redraw = ValueNotifier<bool>(false);
   final _showSelected = ValueNotifier<bool>(false);
   final _counter = ValueNotifier<int>(0);
 
-  List<int> get selectedIds => _selectedIds;
+  List<String> get selectedPsIds => _selectedPsIds;
   ValueNotifier<bool> get showSelected => _showSelected;
   ValueNotifier<bool> get redraw => _redraw;
   ValueNotifier<int> get counter => _counter;
 
-  void init(List<int> ids) {
-    _selectedIds.clear();
-    _selectedIds.addAll(ids);
+  void init(List<String> psIds) {
+    _selectedPsIds.clear();
+    _selectedPsIds.addAll(psIds);
   }
 
   @override
@@ -68,9 +68,9 @@ class MechanicsController extends ChangeNotifier {
   }
 
   void toogleShowSelection() {
-    if (_selectedIds.isEmpty && !_showSelected.value) {
+    if (_selectedPsIds.isEmpty && !_showSelected.value) {
       return;
-    } else if (_selectedIds.isEmpty && _showSelected.value) {
+    } else if (_selectedPsIds.isEmpty && _showSelected.value) {
       _showSelected.value = false;
     } else {
       _showSelected.value = !_showSelected.value;
@@ -80,26 +80,26 @@ class MechanicsController extends ChangeNotifier {
 
   void redrawList() {
     _redraw.value = !_redraw.value;
-    _counter.value = _selectedIds.length;
+    _counter.value = _selectedPsIds.length;
   }
 
   bool isSelectedIndex(int index) {
-    return _selectedIds.contains(mechanics[index].id!);
+    return _selectedPsIds.contains(mechanics[index].psId!);
   }
 
   void toogleSelectionIndex(int index) {
-    int id = mechanics[index].id!;
-    if (_selectedIds.contains(id)) {
-      _selectedIds.remove(id);
+    final psId = mechanics[index].psId!;
+    if (_selectedPsIds.contains(psId)) {
+      _selectedPsIds.remove(psId);
     } else {
-      _selectedIds.add(id);
+      _selectedPsIds.add(psId);
     }
     redrawList();
   }
 
   void toogleSelectedInIndex(int index) {
-    _selectedIds.removeAt(index);
-    if (_selectedIds.isEmpty && _showSelected.value) {
+    _selectedPsIds.removeAt(index);
+    if (_selectedPsIds.isEmpty && _showSelected.value) {
       _showSelected.value = false;
     } else {
       redrawList();
@@ -107,8 +107,8 @@ class MechanicsController extends ChangeNotifier {
   }
 
   void deselectAll() {
-    _selectedIds.clear();
-    if (_selectedIds.isEmpty && _showSelected.value) {
+    _selectedPsIds.clear();
+    if (_selectedPsIds.isEmpty && _showSelected.value) {
       _showSelected.value = false;
     } else {
       redrawList();

--- a/lib/features/mechanics/mechanics_screen.dart
+++ b/lib/features/mechanics/mechanics_screen.dart
@@ -28,11 +28,11 @@ import 'widgets/show_all_mechs.dart';
 import 'widgets/show_selected_mechs.dart';
 
 class MechanicsScreen extends StatefulWidget {
-  final List<int> selectedIds;
+  final List<String> selectedPsIds;
 
   const MechanicsScreen({
     super.key,
-    required this.selectedIds,
+    required this.selectedPsIds,
   });
 
   static const routeName = '/mechanics';
@@ -48,7 +48,7 @@ class _MechanicsScreenState extends State<MechanicsScreen> {
   void initState() {
     super.initState();
 
-    ctrl.init(widget.selectedIds);
+    ctrl.init(widget.selectedPsIds);
   }
 
   @override
@@ -58,7 +58,7 @@ class _MechanicsScreenState extends State<MechanicsScreen> {
   }
 
   void _closeMechanicsPage() {
-    Navigator.pop(context, ctrl.selectedIds);
+    Navigator.pop(context, ctrl.selectedPsIds);
   }
 
   Future<void> _addMechanic() async {
@@ -140,8 +140,8 @@ class _MechanicsScreenState extends State<MechanicsScreen> {
                         isSelectedIndex: ctrl.isSelectedIndex,
                         toogleSelectionIndex: ctrl.toogleSelectionIndex)
                     : ShowAllMechs(
-                        selectedIds: ctrl.selectedIds,
-                        mechanicOfId: ctrl.mechanicOfId,
+                        selectedPsIds: ctrl.selectedPsIds,
+                        mechanicOfPsId: ctrl.mechanicOfPsId,
                         toogleSelectedInIndex: ctrl.toogleSelectedInIndex,
                       ),
                 if (ctrl.state is MechanicsStateLoading)

--- a/lib/features/mechanics/widgets/show_all_mechs.dart
+++ b/lib/features/mechanics/widgets/show_all_mechs.dart
@@ -20,14 +20,14 @@ import 'package:flutter/material.dart';
 import '../../../common/models/mechanic.dart';
 
 class ShowAllMechs extends StatelessWidget {
-  final List<int> selectedIds;
-  final MechanicModel Function(int) mechanicOfId;
+  final List<String> selectedPsIds;
+  final MechanicModel Function(String) mechanicOfPsId;
   final void Function(int) toogleSelectedInIndex;
 
   const ShowAllMechs({
     super.key,
-    required this.selectedIds,
-    required this.mechanicOfId,
+    required this.selectedPsIds,
+    required this.mechanicOfPsId,
     required this.toogleSelectedInIndex,
   });
 
@@ -37,11 +37,11 @@ class ShowAllMechs extends StatelessWidget {
 
     return ListView.separated(
       padding: const EdgeInsets.only(bottom: 70),
-      itemCount: selectedIds.length,
+      itemCount: selectedPsIds.length,
       separatorBuilder: (context, index) =>
           const Divider(indent: 24, endIndent: 24),
       itemBuilder: (context, index) {
-        final mech = mechanicOfId(selectedIds[index]);
+        final mech = mechanicOfPsId(selectedPsIds[index]);
 
         return Container(
           decoration: BoxDecoration(

--- a/lib/features/my_account/widgets/admin_hooks.dart
+++ b/lib/features/my_account/widgets/admin_hooks.dart
@@ -50,7 +50,7 @@ class AdminHooks extends StatelessWidget {
           onTap: () => Navigator.pushNamed(
             context,
             MechanicsScreen.routeName,
-            arguments: <int>[],
+            arguments: <String>[],
           ),
         ),
         ListTile(

--- a/lib/my_material_app.dart
+++ b/lib/my_material_app.dart
@@ -86,12 +86,15 @@ class _MyMaterialAppState extends State<MyMaterialApp> {
               MyAdsScreen.routeName: (_) => const MyAdsScreen(),
               MyDataScreen.routeName: (_) => const MyDataScreen(),
               FavoritesScreen.routeName: (_) => const FavoritesScreen(),
-              EditBoardgamesScreen.routeName: (_) =>
-                  const EditBoardgamesScreen(),
               BoardgameScreen.routeName: (_) => const BoardgameScreen(),
             },
             onGenerateRoute: (settings) {
               switch (settings.name) {
+                case EditBoardgamesScreen.routeName:
+                  return MaterialPageRoute(builder: (context) {
+                    final bg = settings.arguments as BoardgameModel?;
+                    return EditBoardgamesScreen(bg);
+                  });
                 case EditAdScreen.routeName:
                   return MaterialPageRoute(builder: (context) {
                     final ad = settings.arguments as AdModel?;
@@ -114,10 +117,10 @@ class _MyMaterialAppState extends State<MyMaterialApp> {
 
                 case MechanicsScreen.routeName:
                   return MaterialPageRoute(builder: (context) {
-                    final selectedIds = settings.arguments as List<int>;
+                    final selectedPsIds = settings.arguments as List<String>;
 
                     return MechanicsScreen(
-                      selectedIds: selectedIds,
+                      selectedPsIds: selectedPsIds,
                     );
                   });
 

--- a/lib/repository/parse_server/common/constants.dart
+++ b/lib/repository/parse_server/common/constants.dart
@@ -91,6 +91,5 @@ const keyBgMechanics = 'mechanics';
 
 const keyMechTable = mechTable;
 const keyMechObjectId = 'objectId';
-const keyMechId = 'mechId'; // id is an invalid field name for parse server
 const keyMechName = mechName;
 const keyMechDescription = mechDescription;

--- a/lib/repository/parse_server/common/parse_to_model.dart
+++ b/lib/repository/parse_server/common/parse_to_model.dart
@@ -92,7 +92,7 @@ class ParseToModel {
       images: (parse.get<List<dynamic>>(keyAdImages) as List<dynamic>)
           .map((item) => (item as ParseFile).url!)
           .toList(),
-      mechanicsId: mechs.map((e) => e as int).toList(),
+      mechanicsId: mechs.map((e) => e as String).toList(),
       address: address,
       status: AdStatus.values
           .firstWhere((s) => s.index == parse.get<int>(keyAdStatus)!),
@@ -124,7 +124,7 @@ class ParseToModel {
     final mechs = parse.get<List<dynamic>>(keyBgMechanics)!;
 
     return BoardgameModel(
-      id: parse.objectId,
+      bgId: parse.objectId,
       name: parse.get<String>(keyBgName)!,
       image: parse.get<ParseFile>(keyBgImage)!.url!,
       publishYear: parse.get<int>(keyBgPublishYear)!,
@@ -137,7 +137,7 @@ class ParseToModel {
       artist: parse.get<String?>(keyBgArtist)!,
       description: parse.get<String?>(keyBgDescription)!,
       views: parse.get<int>(keyBgViews)!,
-      mechanics: mechs.map((item) => item as int).toList(),
+      mechsPsIds: mechs.map((item) => item as String).toList(),
     );
   }
 
@@ -153,7 +153,7 @@ class ParseToModel {
 
   static MechanicModel mechanic(ParseObject parse) {
     return MechanicModel(
-      id: parse.get<int>(keyMechId)!,
+      psId: parse.objectId,
       name: parse.get<String>(keyMechName)!,
       description: parse.get<String>(keyMechDescription)!,
     );

--- a/lib/repository/parse_server/ps_ad_repository.dart
+++ b/lib/repository/parse_server/ps_ad_repository.dart
@@ -179,8 +179,8 @@ class PSAdRepository {
       }
 
       // Filter by machanics
-      if (filter.mechanicsId.isNotEmpty) {
-        for (final mechId in filter.mechanicsId) {
+      if (filter.mechanicsPsId.isNotEmpty) {
+        for (final mechId in filter.mechanicsPsId) {
           final mechParse = ParseObject(keyMechanicTable)
             ..set(keyMechanicId, mechId);
           query.whereEqualTo(keyAdMechanics, mechParse.toPointer());
@@ -281,7 +281,7 @@ class PSAdRepository {
         ..set<String?>(keyAdArtist, ad.artist)
         ..set<ParseObject>(keyAdAddress, parseAddress)
         ..set<List<ParseFile>>(keyAdImages, parseImages)
-        ..set<List<int>>(keyAdMechanics, ad.mechanicsId);
+        ..set<List<String>>(keyAdMechanics, ad.mechanicsId);
 
       final response = await parseAd.save();
       if (!response.success) {
@@ -338,7 +338,7 @@ class PSAdRepository {
         ..set<String?>(keyAdArtist, ad.artist)
         ..set<ParseObject>(keyAdAddress, parseAddress)
         ..set<List<ParseFile>>(keyAdImages, parseImages)
-        ..set<List<int>>(keyAdMechanics, ad.mechanicsId);
+        ..set<List<String>>(keyAdMechanics, ad.mechanicsId);
 
       final response = await parseAd.update();
       if (!response.success) {

--- a/lib/repository/parse_server/ps_boardgame_repository.dart
+++ b/lib/repository/parse_server/ps_boardgame_repository.dart
@@ -60,9 +60,58 @@ class PSBoardgameRepository {
         ..set<String?>(keyBgArtist, bg.artist)
         ..set<String?>(keyBgDescription, bg.description)
         ..set<int?>(keyBgViews, bg.views)
-        ..set<List<int>>(keyBgMechanics, bg.mechanics);
+        ..set<List<String>>(keyBgMechanics, bg.mechsPsIds);
 
       final response = await parse.save();
+      if (!response.success) {
+        throw Exception(response.error);
+      }
+
+      return ParseToModel.boardgameModel(parse);
+    } catch (err) {
+      final message = 'AdRepository.save: $err';
+      log(message);
+      return null;
+    }
+  }
+
+  static Future<BoardgameModel?> update(BoardgameModel bg) async {
+    try {
+      final parse = ParseObject(keyBgTable);
+
+      final parseUser = await ParseUser.currentUser() as ParseUser?;
+      if (parseUser == null) {
+        throw Exception('Current user access error');
+      }
+
+      final parseImage = await _saveImage(
+        path: bg.image,
+        parseUser: parseUser,
+        fileName: '${bg.name}_${bg.publishYear}.jpg',
+      );
+
+      final parseAcl = ParseACL(owner: parseUser);
+      parseAcl.setPublicReadAccess(allowed: true);
+      parseAcl.setPublicWriteAccess(allowed: false);
+
+      parse
+        ..objectId = bg.bgId
+        ..setACL(parseAcl)
+        ..set<String>(keyBgName, bg.name)
+        ..set<ParseFile>(keyBgImage, parseImage)
+        ..set<int>(keyBgPublishYear, bg.publishYear)
+        ..set<int>(keyBgMinPlayers, bg.minPlayers)
+        ..set<int>(keyBgMaxPlayers, bg.maxPlayers)
+        ..set<int>(keyBgMinTime, bg.minTime)
+        ..set<int>(keyBgMaxTime, bg.maxTime)
+        ..set<int>(keyBgMinAge, bg.minAge)
+        ..set<String?>(keyBgDesigner, bg.designer)
+        ..set<String?>(keyBgArtist, bg.artist)
+        ..set<String?>(keyBgDescription, bg.description)
+        ..set<int?>(keyBgViews, bg.views)
+        ..set<List<String>>(keyBgMechanics, bg.mechsPsIds);
+
+      final response = await parse.update();
       if (!response.success) {
         throw Exception(response.error);
       }

--- a/lib/repository/parse_server/ps_mechanics_repository.dart
+++ b/lib/repository/parse_server/ps_mechanics_repository.dart
@@ -42,7 +42,6 @@ class PSMechanicsRepository {
 
       parse
         ..setACL(parseAcl)
-        ..set<int>(keyMechId, mech.id!)
         ..set<String>(keyMechName, mech.name)
         ..set<String>(keyMechDescription, mech.description!);
 
@@ -85,11 +84,11 @@ class PSMechanicsRepository {
     }
   }
 
-  static Future<List<int>> getIds() async {
+  static Future<List<String>> getPsIds() async {
     final query = QueryBuilder<ParseObject>(ParseObject(keyMechTable));
 
     try {
-      query.keysToReturn([keyMechId]);
+      query.keysToReturn([keyMechObjectId]);
 
       final response = await query.query();
       if (!response.success) {
@@ -98,10 +97,10 @@ class PSMechanicsRepository {
         throw Exception(message);
       }
 
-      final List<int> mechs = [];
+      final List<String> mechs = [];
       for (final ParseObject parse in response.results!) {
-        final id = parse.get<int>(keyMechId)!;
-        mechs.add(id);
+        final id = parse.objectId;
+        mechs.add(id!);
       }
       return mechs;
     } catch (err) {

--- a/lib/store/constants/migration_sql_scripts.dart
+++ b/lib/store/constants/migration_sql_scripts.dart
@@ -28,5 +28,6 @@ class MigrationSqlScripts {
       'ALTER TABLE $mechTable ADD COLUMN $mechPSId CHAR(10)',
       'CREATE INDEX IF NOT EXISTS $mechIndexPSId ON $mechTable ($mechPSId)',
     ],
+    1002: [],
   };
 }

--- a/lib/store/stores/mechanics_store.dart
+++ b/lib/store/stores/mechanics_store.dart
@@ -30,7 +30,7 @@ class MechanicsStore {
     try {
       List<Map<String, dynamic>> result = await database.query(
         mechTable,
-        columns: [mechId, mechName, mechDescription],
+        columns: [mechId, mechPSId, mechName, mechDescription],
         orderBy: mechName,
       );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bgbazzar
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.6.17+43
+version: 0.6.17+44
 
 environment:
   sdk: '>=3.4.1 <4.0.0'


### PR DESCRIPTION
Update: Refactor Mechanics IDs and Various Model Updates. Files and Changes:

1. `lib/common/models/ad.dart`
   - Updated `mechanicsId` from `List<int>` to `List<String>` to reflect changes in ID management.

2. `lib/common/models/boardgame.dart`
   - Renamed the `id` field to `bgId`.
   - Updated `mechanics` to `mechsPsIds`, changing the type from `List<int>` to `List<String>`.

3. `lib/common/models/filter.dart`
   - Changed `mechanicsId` to `mechanicsPsId` and updated its type from `List<int>` to `List<String>`.

4. `lib/common/settings/local_server.dart`
   - Added `keyParseServerImageUrl` to manage image URLs more efficiently.

5. `lib/common/singletons/app_settings.dart`
   - Enhanced `_saveBright()` to save brightness settings as 'dark' or 'light' strings.

6. `lib/components/custon_field_controllers/numeric_edit_controller.dart`
   - Improved the `numericValue` setter to better manage old values and trigger appropriate UI updates.

7. `lib/components/others_widgets/spin_box_field.dart`
   - Refactored to use generics, allowing support for both `int` and `double` types in `SpinBoxField`.

8. `lib/features/boardgame/boardgame_screen.dart`
   - Refined the floating action button to allow for multiple actions with tooltips for better UX.

9. `lib/features/edit_ad/edit_ad_controller.dart`
   - Updated `setMechanicsIds()` to `setMechanicsPsIds()` to handle the new `String` ID format.

10. `lib/features/edit_ad/widgets/ad_form.dart`
    - Refactored to use the new `setMechanicsPsIds()` method.

11. `lib/features/edit_boardgame/edit_boardgame_controller.dart` - Updated mechanics handling to reflect changes from `int` to `String` for IDs. - Introduced a method for updating existing board games.

12. `lib/features/edit_boardgame/edit_boardgame_screen.dart` - Modified the initialization to pass `BoardgameModel` objects where applicable.

13. `lib/features/filters/filters_controller.dart` - Changed `selectedMechIds` from `List<int>` to `List<String>`. - Updated method calls to align with this change.

14. `lib/features/filters/filters_screen.dart` - Refined the mechanics selection process to handle `String` IDs.

15. `lib/features/mechanics/mechanics_controller.dart` - Adapted the controller to work with `String` IDs. - Updated methods for selecting and managing mechanics.

16. `lib/features/mechanics/mechanics_screen.dart` - Updated arguments and state management to work with `String` IDs instead of `int`.

17. `lib/features/mechanics/widgets/show_all_mechs.dart` - Refined to handle `String` IDs, ensuring compatibility with the rest of the application.

18. `lib/features/my_account/widgets/admin_hooks.dart` - Adjusted to pass `String` IDs in the navigation arguments for mechanics management.

19. `lib/manager/boardgames_manager.dart` - Implemented `update()` method to handle board game updates with the new `String` ID format. - Renamed `saveNewBoardgame()` to `save()` for consistency.

20. `lib/manager/mechanics_manager.dart` - Updated to handle `String` IDs for mechanics. - Modified the `add()` method to return the new mechanic after saving it to the server.

21. `lib/my_material_app.dart` - Adjusted routes to pass `BoardgameModel` objects where required. - Updated mechanics selection to handle `String` IDs.

22. `lib/repository/parse_server/common/constants.dart` - Removed the now redundant `keyMechId` constant.

23. `lib/repository/parse_server/common/parse_to_model.dart` - Updated parsing logic to handle `String` IDs for mechanics and board games.

24. `lib/repository/parse_server/ps_ad_repository.dart` - Refined to work with `String` IDs for mechanics within advertisements.

25. `lib/repository/parse_server/ps_boardgame_repository.dart` - Implemented an `update()` method for board games, ensuring proper handling of the new `String` IDs.

26. `lib/repository/parse_server/ps_mechanics_repository.dart` - Changed method names and return types to work with `String` IDs. - Removed the setting of `mechId` in the `add()` method, now relying on `objectId`.

27. `lib/store/constants/migration_sql_scripts.dart` - Added a placeholder for a future migration script (version 1002).

28. `lib/store/stores/mechanics_store.dart` - Updated queries to include the new `mechPSId` column.

This commit introduces significant changes to the handling of mechanics and board game IDs across the codebase, migrating from `int` to `String` IDs for better compatibility with the Parse server. The update also includes improvements in UI components and overall data management.